### PR TITLE
fix: 権限を持っているのに削除機能が利用できない

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
+# Discord Botのトークンを指定します。
+# https://citation.m2en.dev/guide/install-guide/create-bot.html
 CITATION_BOT_TOKEN=
+
+# ギルドのIDを指定します。
 GUILD_ID=

--- a/src/main/kotlin/dev/m2en/citation/api/event/CitationCreateEvent.kt
+++ b/src/main/kotlin/dev/m2en/citation/api/event/CitationCreateEvent.kt
@@ -15,6 +15,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.components.buttons.Button
 
+// TODO: 権限のチェックを追加する (MESSAGE_SEND)
 class CitationCreateEvent : ListenerAdapter() {
 
     /**

--- a/src/main/kotlin/dev/m2en/citation/api/event/CitationDeleteEvent.kt
+++ b/src/main/kotlin/dev/m2en/citation/api/event/CitationDeleteEvent.kt
@@ -30,8 +30,14 @@ class CitationDeleteEvent : ListenerAdapter() {
             return
         }
 
+        if(checkRequesterPermission(requester)) {
+            event.replyEmbeds(EmbedBuilder.buildEmbed("削除に成功しました。", "権限を持っていたため、IDの確認は行われません。")).setEphemeral(true).queue()
+            target.delete().queue()
+            Logger.sendInfo("${requester.user.name} の削除リクエストを受理しました。(権限バイパスあり)")
+            return
+        }
 
-        if (!checkRequesterPermission(requester) && event.componentId != requester.id) {
+        if (event.componentId != requester.id) {
             event.replyEmbeds(EmbedBuilder.buildErrorEmbed("削除に失敗しました", "あなたの引用ではないため、削除できません。")).setEphemeral(true).queue()
             return
         }

--- a/src/main/kotlin/dev/m2en/citation/api/event/CitationDeleteEvent.kt
+++ b/src/main/kotlin/dev/m2en/citation/api/event/CitationDeleteEvent.kt
@@ -62,8 +62,10 @@ class CitationDeleteEvent : ListenerAdapter() {
     }
 
     private fun checkRequesterPermission(requester: Member): Boolean {
-        if (!requester.hasPermission(Permission.MESSAGE_MANAGE)) return false
-        if (!requester.hasPermission(Permission.ADMINISTRATOR)) return false
+        if (!requester.hasPermission(Permission.MESSAGE_MANAGE) && !requester.hasPermission(Permission.ADMINISTRATOR)) {
+            return false
+        }
+
         return true
     }
 }


### PR DESCRIPTION
### 関連したIssue

close #105 

<!-- 
    このプルリクエストに関連したIssueの番号を入力します。(ここで入力された番号のIssueが関連するIssueとして扱われます。)
    ここで指定された関連Issueは、プルリクエストがマージされ閉じられた際に自動的に閉じられます。
    複数のIssueを指定する際は、close #1, close #2 のように記述してください。
    詳細: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### 概要

権限のチェックを変更し、削除機能を修正しました。
