### PR TITLE
ci: Trivyの脆弱性スキャンを行うCIの追加

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  build:
-    name: Build citation Docker Image
+  scan:
+    name: Run Trivy vulnerability scanner
     runs-on: ubuntu-22.04
 
     steps:
@@ -18,11 +18,6 @@ jobs:
         run: |
           docker build ./ -t citation
 
-  scan:
-    name: Run Trivy vulnerability scanner
-    runs-on: ubuntu-22.04
-
-    steps:
       - name: Scan image
         uses: aquasecurity/trivy-action@0.8.0
         with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,36 @@
+name: trivy scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    name: Build citation Docker Image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build image from Dockerfile
+        run: |
+          docker build ./ -t citation
+
+  scan:
+    name: Run Trivy vulnerability scanner
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Scan image
+        uses: aquasecurity/trivy-action@v0.8.0
+        with:
+          image-ref: citation
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Send report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Scan image
-        uses: aquasecurity/trivy-action@v0.8.0
+        uses: aquasecurity/trivy-action@0.8.0
         with:
           image-ref: citation
           format: 'sarif'


### PR DESCRIPTION
[Trivy](https://github.com/aquasecurity/trivy) によるDocker Imageの脆弱性スキャンを行うCIを追加します。

`main` ブランチにプッシュされるか、新しいバージョンがリリースされたら実行され、脆弱性を孕んだDocker ImageがあればGitHub Security Tabに通知される仕組みです。