### PR TITLE
ci(fix): Dependabot のコミットに対しての Trivy CI が落ちる

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -3,11 +3,10 @@ name: trivy scan
 on:
   push:
     branches:
-      - main
-    branches-ignore:
       # Dependabot のプッシュでの Workflows は読み取り専用権限として実行される
       # この場合は Code Scanning は使用できないため、Dependabot のプッシュはスキャン対象に含めない
-      - 'dependabot/**/main/**'
+      - '!dependabot/**/main/**'
+      - main
   # プルリクエストの場合は上記の影響を受けないため、いつもどおりスキャンを行う
   pull_request:
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    branches-ignore:
+      # Dependabot のプッシュでの Workflows は読み取り専用権限として実行される
+      # この場合は Code Scanning は使用できないため、Dependabot のプッシュはスキャン対象に含めない
+      - 'dependabot/**/main/**'
+  # プルリクエストの場合は上記の影響を受けないため、いつもどおりスキャンを行う
   pull_request:
 
 jobs:

--- a/src/main/kotlin/dev/m2en/citation/api/event/CitationCreateEvent.kt
+++ b/src/main/kotlin/dev/m2en/citation/api/event/CitationCreateEvent.kt
@@ -23,7 +23,7 @@ class CitationCreateEvent : ListenerAdapter() {
      * GuildId/ChannelId/MessageId
      */
     private val linkRegex =
-        Regex("""https://(?:ptb\.|canary\.)?discord(?:app)?.com/channels/(\d+)/(\d+)/(\d+)""")
+        Regex("""https://(?:ptb\.|canary\.)?discord(?:app)?\.com/channels/(\d+)/(\d+)/(\d+)""")
 
     /**
      * スキップ対象のメッセージリンクを取り出す正規表現

--- a/src/main/kotlin/dev/m2en/citation/api/event/ReadyEvent.kt
+++ b/src/main/kotlin/dev/m2en/citation/api/event/ReadyEvent.kt
@@ -11,7 +11,7 @@ import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.events.session.ReadyEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 
-private val RECOMMEND_PERMISSION = mutableListOf(
+private val recommendPermission = mutableListOf(
     Permission.VIEW_CHANNEL,
     Permission.MESSAGE_SEND,
     Permission.MESSAGE_SEND_IN_THREADS,
@@ -19,6 +19,7 @@ private val RECOMMEND_PERMISSION = mutableListOf(
     Permission.MESSAGE_ATTACH_FILES,
     Permission.MESSAGE_HISTORY,
 )
+
 class ReadyEvent(private val tag: String?) : ListenerAdapter() {
 
     override fun onReady(event: ReadyEvent) {
@@ -46,7 +47,7 @@ class ReadyEvent(private val tag: String?) : ListenerAdapter() {
 
         if(event.guildAvailableCount == 0 || event.jda.guildCache.isEmpty) {
             Logger.sendWarn("citationが接続したBotはどこのギルドにも所属していないか、利用できるギルドが存在しません。")
-            Logger.sendWarn("招待リンクを使用して招待してください。[${event.jda.getInviteUrl(RECOMMEND_PERMISSION)}]")
+            Logger.sendWarn("招待リンクを使用して招待してください。[${event.jda.getInviteUrl(recommendPermission)}]")
         }
 
         val guild = event.jda.getGuildById(Utils.getEnv("GUILD_ID")) ?: throw NumberFormatException(

--- a/src/main/kotlin/dev/m2en/citation/api/event/ReadyEvent.kt
+++ b/src/main/kotlin/dev/m2en/citation/api/event/ReadyEvent.kt
@@ -11,6 +11,10 @@ import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.events.session.ReadyEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 
+/**
+ * citation の推奨権限はドキュメントを参照してください。
+ * https://citation.m2en.dev/guide/install-guide/create-bot.html
+ */
 private val recommendPermission = mutableListOf(
     Permission.VIEW_CHANNEL,
     Permission.MESSAGE_SEND,


### PR DESCRIPTION
### 関連したIssue

close #126 

### 概要

@dependabot がプッシュしたコミットに対して Trivy CI が落ちてしまう問題を修正しました。

@dependabot のコミットのブランチを確認し、ヒットした場合は無視します。

プルリクエストに対してのスキャンは今までどおり実行されます。